### PR TITLE
Further linker fixes, and update to latest packages

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,16 +4,12 @@ rustflags = [
     "-C", "link-arg=-nostartfiles",
 
     "-C", "link-arg=-mthumb",
-   # "-C", "link-arg=-specs=nano.specs",
-    #"-C", "link-arg=-specs=nosys.specs",
+    # "-C", "link-arg=-specs=nano.specs",
+    "-C", "link-arg=-specs=nosys.specs",
     "-C", "link-arg=-Wl,-Tdevice.x",
     "-C", "link-arg=-mcpu=cortex-m4",
 
-    "-C", "link-arg=-Wl,-lgcc",
-    "-C", "link-arg=-Wl,-lc",
     "-C", "link-arg=-Wl,--gc-sections",
-    "-C", "link-arg=-Wl,--start-group",
-    "-C", "link-arg=-Wl,--end-group",
     "-C", "link-arg=-Wl,--build-id=none",
 
     "-C", "link-arg=-mabi=aapcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ description = "nrf52 support using the nRF5-SDK and SoftDevice S132"
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.5.8"
-cortex-m-rt = "0.6.5"
-cortex-m-semihosting = "0.3.2"
+cortex-m = "0.6.0"
+cortex-m-rt = "0.6.8"
+cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
 
 [build-dependencies]
-cc = "1.0.29"
+cc = "1.0.37"
 
 [profile.release]
 codegen-units = 1 # better optimizations

--- a/device.x
+++ b/device.x
@@ -1,4 +1,7 @@
 /* Linker script for the nRF52832_xxAA - WITH SOFT DEVICE */
+SEARCH_DIR(.)
+GROUP(AS_NEEDED(-lgcc -lc -lnosys))
+
 MEMORY
 {
   /* NOTE K = KiBi = 1024 bytes */
@@ -170,6 +173,8 @@ SECTIONS
 
   /* Place the heap right after `.bss` */
   __sheap = ADDR(.bss) + SIZEOF(.bss);
+
+  PROVIDE(end = __sheap);
 
   /* Stack usage metadata emitted by LLVM */
   .stack_sizes (INFO) :


### PR DESCRIPTION
- device.x: Correct linker errors by including `libnosys` and defining `end`
- .cargo/config: remove unneeded linker flags
- Cargo.toml: update to latest crates

> Note: I was able to attach a gdb remote debugger and see it step through the loop on blinky, but did not see a blinking light on my nRF52840DK board. I did not go further and try to verify the ble template, although it does now compile. I do not know what steps are needed to massage the SDK to contain my board definition.